### PR TITLE
Language specific navigation header

### DIFF
--- a/main.php
+++ b/main.php
@@ -154,7 +154,7 @@ if (tpl_getConf("prsnl10_loaduserjs")){
                 if (empty($conf["useacl"]) ||
                     auth_quickaclcheck(cleanID(tpl_getConf("prsnl10_headernav_location")))){ //current user got access?
                     //get the rendered content of the defined wiki article to use as custom navigation
-                    $interim = tpl_include_page(tpl_getConf("prsnl10_headernav_location"), false);
+                    $interim = tpl_include_page(tpl_getConf("prsnl10_headernav_location"), false, true);
                     if ($interim === "" ||
                         $interim === false){
                         //show creation/edit link if the defined page got no content


### PR DESCRIPTION
Now it is impossible to have separate headers for different languages. This commit solves this problem.

If the third parameter of _tpl_include_page_ is true and the page is not found, it searches in the current and parent namespaces. If we could have two pages "de:wiki:navigation_header" and "en:wiki:navigation_header" (but not conventional ":wiki:navigation_header"), the corresponding page will be selected according to the current namespace ('de:', 'en:').
